### PR TITLE
feat(template): add format for talk proposition

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,3 +15,4 @@ Pour le titre de l'issue, merci de respecter cette notation : [NOM DE VOTRE CONF
 * Thématique, Labels :
 * Niveau de difficulté (débutant|avancé|confirmé) :
 * Durée (max 45 min) : 
+* Format (slides, live-coding, les deux): 


### PR DESCRIPTION
The distinction between `Slide only` and `Live coding` could be useful to know if those presentation can be done in a standard computer or with one containing custom environment...